### PR TITLE
json parser + minor function call param change

### DIFF
--- a/agentai/api.py
+++ b/agentai/api.py
@@ -1,7 +1,6 @@
 """
 API functions for the agentai package
 """
-import json
 from typing import Any, Callable, Tuple, Union
 
 from loguru import logger
@@ -17,6 +16,7 @@ from tenacity import (
 
 from .conversation import Conversation
 from .tool_registry import ToolRegistry
+from .utils.parse_json import parse_json
 
 logger.disable(__name__)
 
@@ -79,16 +79,14 @@ def chat_complete_execute_fn(
         conversation=conversation,
         tool_registry=tool_registry,
         model=model,
-        function_call=True,
+        function_call="auto",
     )
     message = completion.choices[0].message
     function_call = message["function_call"]
-    function_arguments = json.loads(function_call["arguments"])
-    logger.info(f"function_arguments: {function_arguments}")
+    function_arguments = parse_json(function_call["arguments"])
     callable_function = tool_registry.get(function_call["name"])
     logger.info(f"callable_function: {callable_function}")
-    callable_function.validate(**function_arguments)
-    logger.info("Validated function arguments")
+    # callable_function.validate(**function_arguments)
+    # logger.info("Validated function arguments")
     results = callable_function(**function_arguments)
-    logger.info(f"results: {results}")
     return results, function_arguments, callable_function

--- a/agentai/utils/parse_json.py
+++ b/agentai/utils/parse_json.py
@@ -1,0 +1,69 @@
+import re
+import json
+
+
+# From https://github.com/Stevenic/alphawave-py/blob/main/src/alphawave/Response.py#L26
+def parse_json(text):
+    text = "".join(c for c in text if c.isprintable())
+    text = text.replace("{\n", "{")
+    text = text.replace("}\n", "}")
+    # text = re.sub(r"'([^\"']+)'", r'"\1"', text) # all pairs as doublequote
+    text = re.sub(r"'([^\"']+)':", r'"\1":', text)  # keys as doublequote
+    # text = re.sub(r'"([^\'"]+)":', r"'\1':", text) # keys as singlequote
+    # text = text.replace("'", '"')
+    # text = text.replace("\'", '"')
+    start_brace = text.find("{")
+    if start_brace >= 0:
+        obj_text = text[start_brace:]
+        nesting = ["}"]
+        cleaned = "{"
+        in_string = False
+        i = 1
+        while i < len(obj_text) and len(nesting) > 0:
+            ch = obj_text[i]
+            if in_string:
+                cleaned += ch
+                if ch == "\\":
+                    i += 1
+                    if i < len(obj_text):
+                        cleaned += obj_text[i]
+                    else:
+                        return None
+                elif ch == '"':
+                    in_string = False
+            else:
+                if ch == '"':
+                    in_string = True
+                elif ch == "{":
+                    nesting.append("}")
+                elif ch == "[":
+                    nesting.append("]")
+                elif ch == "}":
+                    close_object = nesting.pop()
+                    if close_object != "}":
+                        return None
+                elif ch == "]":
+                    close_array = nesting.pop()
+                    if close_array != "]":
+                        return None
+                elif ch == "<":
+                    ch = '"<'
+                elif ch == ">":
+                    ch = '>"'
+                cleaned += ch
+            i += 1
+
+        if len(nesting) > 0:
+            cleaned += "".join(reversed(nesting))
+
+        try:
+            if type(cleaned) == str:
+                obj = json.loads(cleaned)
+                return obj
+            else:
+                return cleaned
+            return obj if len(obj.keys()) > 0 else None
+        except json.JSONDecodeError:
+            return cleaned
+    else:
+        return None


### PR DESCRIPTION
This PR has 3 changes related to function execution with chat.

1. Added an extra parser from [https://github.com/Stevenic/alphawave-py](https://github.com/Stevenic/alphawave-py). Some of the function arguments returned by openai weren't being parsed by json.loads(). Hence added this.
2. Changed the function_call param from True to "auto" as per [https://platform.openai.com/docs/api-reference/chat/create#function_call](https://platform.openai.com/docs/api-reference/chat/create#function_call)
3. Commented out argument validator for now as it was failing with (AttributeError: 'function' object has no attribute 'validate'). Anywhere I can read about this, that is not a pydantic decorator? 